### PR TITLE
Fix issue with escaped character during export

### DIFF
--- a/src/lib/n98-magerun/modules/Zookal_HarrisStreetImpex/src/HarrisStreet/CoreConfigData/Exporter/Yaml.php
+++ b/src/lib/n98-magerun/modules/Zookal_HarrisStreetImpex/src/HarrisStreet/CoreConfigData/Exporter/Yaml.php
@@ -86,6 +86,7 @@ class Yaml extends AbstractExporter
             return "|\n" . $value;
         }
 
-        return '\'' . addcslashes($value, '\'') . '\'';
+		return '"' . addcslashes($value, '"') . '"';
+
     }
 }

--- a/src/lib/n98-magerun/modules/Zookal_HarrisStreetImpex/src/HarrisStreet/CoreConfigData/Exporter/Yaml.php
+++ b/src/lib/n98-magerun/modules/Zookal_HarrisStreetImpex/src/HarrisStreet/CoreConfigData/Exporter/Yaml.php
@@ -86,7 +86,6 @@ class Yaml extends AbstractExporter
             return "|\n" . $value;
         }
 
-		return '"' . addcslashes($value, '"') . '"';
-
+        return '"' . addcslashes($value, '"') . '"';
     }
 }


### PR DESCRIPTION
If a configuration value has a single quote, it will be escaped. e.g. 

```
'Our price is lower than the manufacturer\'s "minimum advertised price."  As a result, we cannot show you the price in catalog or the product page. <br /><br /> You have no obligation to purchase the product once you know the price. You can simply remove the item from your cart.'
```

The import parser for YAML provide an error and doesn't import the content.

By changing from single quote to double quote for text delimitation and escaping those double quote the import has no issue.

```
"Our price is lower than the manufacturer's \"minimum advertised price.\"  As a result, we cannot show you the price in catalog or the product page. <br /><br /> You have no obligation to purchase the product once you know the price. You can simply remove the item from your cart."
```
