### PR TITLE
Stop switch parsing before path and value in config:set

### DIFF
--- a/src/lib/n98-magerun/modules/Zookal_HarrisStreetImpex/src/HarrisStreet/CoreConfigData/Import.php
+++ b/src/lib/n98-magerun/modules/Zookal_HarrisStreetImpex/src/HarrisStreet/CoreConfigData/Import.php
@@ -167,7 +167,7 @@ class Import extends AbstractImpex
                 if ($value === self::DELETE_VALUE) {
                     $return[] = 'config:delete --scope=' . $scope . ' --scope-id=' . $scopeId . ' "' . $path . '"';
                 } else {
-                    $return[] = 'config:set --scope=' . $scope . ' --scope-id=' . $scopeId . ' "' . $path . '" "' . $value . '"';
+                    $return[] = 'config:set --scope=' . $scope . ' --scope-id=' . $scopeId . ' -- "' . $path . '" "' . $value . '"';
                 }
             }
         }


### PR DESCRIPTION
We had an issue with strings as config values containing words (white-space separated) that started with two dashes as those were interpreted as additional options (which then were undefined).

This proposed change did levitate the problem on our end.